### PR TITLE
feat: use Segment font globally

### DIFF
--- a/src/app/api/og/transaction/route.tsx
+++ b/src/app/api/og/transaction/route.tsx
@@ -10,6 +10,14 @@ export const runtime = 'edge';
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
+
+    const segmentRegular = await fetch(
+      new URL('../../../../../public/fonts/Segment/Segment-Medium.otf', import.meta.url)
+    ).then(res => res.arrayBuffer());
+
+    const segmentBold = await fetch(
+      new URL('../../../../../public/fonts/Segment/Segment-Bold.otf', import.meta.url)
+    ).then(res => res.arrayBuffer());
     
     // Parse transaction data from query parameters
     const safeTxHash = searchParams.get('safeTxHash');
@@ -45,6 +53,20 @@ export async function GET(request: NextRequest) {
         {
           width: 1200,
           height: 630,
+          fonts: [
+            {
+              name: 'Segment',
+              data: segmentRegular,
+              style: 'normal',
+              weight: 500,
+            },
+            {
+              name: 'Segment',
+              data: segmentBold,
+              style: 'normal',
+              weight: 700,
+            },
+          ],
         }
       );
     }
@@ -110,11 +132,32 @@ export async function GET(request: NextRequest) {
       {
         width: 1200,
         height: 630,
+        fonts: [
+          {
+            name: 'Segment',
+            data: segmentRegular,
+            style: 'normal',
+            weight: 500,
+          },
+          {
+            name: 'Segment',
+            data: segmentBold,
+            style: 'normal',
+            weight: 700,
+          },
+        ],
       }
     );
   } catch (error) {
     console.error('Error generating OG image:', error);
-    
+    const segmentRegular = await fetch(
+      new URL('../../../../../public/fonts/Segment/Segment-Medium.otf', import.meta.url)
+    ).then(res => res.arrayBuffer());
+
+    const segmentBold = await fetch(
+      new URL('../../../../../public/fonts/Segment/Segment-Bold.otf', import.meta.url)
+    ).then(res => res.arrayBuffer());
+
     return new ImageResponse(
       (
         <div
@@ -136,6 +179,20 @@ export async function GET(request: NextRequest) {
       {
         width: 1200,
         height: 630,
+        fonts: [
+          {
+            name: 'Segment',
+            data: segmentRegular,
+            style: 'normal',
+            weight: 500,
+          },
+          {
+            name: 'Segment',
+            data: segmentBold,
+            style: 'normal',
+            weight: 700,
+          },
+        ],
       }
     );
   }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,5 +2,5 @@
 @plugin "daisyui";
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-segment), sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,23 @@
 import type { Metadata } from "next";
-import { Geist } from "next/font/google";
+import localFont from "next/font/local";
 import { AuthProvider } from "@/components/providers/AuthProvider";
 import { ThemeProvider } from "@/components/providers/ThemeProvider";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+const segment = localFont({
+  src: [
+    {
+      path: "../../public/fonts/Segment/Segment-Medium.otf",
+      weight: "500",
+      style: "normal",
+    },
+    {
+      path: "../../public/fonts/Segment/Segment-Bold.otf",
+      weight: "700",
+      style: "normal",
+    },
+  ],
+  variable: "--font-segment",
 });
 
 export const metadata: Metadata = {
@@ -29,9 +35,7 @@ export default function RootLayout({
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </head>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${segment.variable} antialiased`}>
         <ThemeProvider>
           <AuthProvider>
             {children}

--- a/src/components/og/TransactionImage.tsx
+++ b/src/components/og/TransactionImage.tsx
@@ -46,7 +46,7 @@ export function TransactionImage({
         backgroundColor: '#0f172a',
         color: 'white',
         padding: '40px',
-        fontFamily: 'Inter, system-ui, sans-serif',
+        fontFamily: 'Segment, sans-serif',
       }}
     >
       {/* Header */}
@@ -325,7 +325,7 @@ function DetailRow({
       <div
         style={{
           display: 'flex',
-          fontFamily: isMonospace ? 'monospace' : 'inherit',
+          fontFamily: isMonospace ? 'Segment, monospace' : 'Segment',
           fontWeight: 'bold',
           color: valueColor,
         }}
@@ -501,7 +501,7 @@ function TransactionFooter({ chainName, safeTxHash }: { chainName: string; safeT
       <div
         style={{
           display: 'flex',
-          fontFamily: 'monospace',
+          fontFamily: 'Segment, monospace',
           fontSize: '14px',
         }}
       >


### PR DESCRIPTION
## Summary
- replace Geist with locally hosted Segment font and apply globally
- render OG transaction images with Segment typeface

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: A `require()` style import is forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68aab67b1ea88331ba3002bea557ee04